### PR TITLE
Fix TLS detection to connect to Aerospike

### DIFF
--- a/internal/pkg/dataprovider/aero_server.go
+++ b/internal/pkg/dataprovider/aero_server.go
@@ -100,7 +100,7 @@ func initAerospikeTLS() *tls.Config {
 	// load the server / client certificates
 	serverPool, clientPool = commons.LoadServerOrClientCertificates()
 
-	if serverPool != nil && clientPool != nil {
+	if serverPool != nil || clientPool != nil {
 		// we either have server pool or client pool of certificates
 		tlsConfig := &tls.Config{
 			Certificates:             clientPool,


### PR DESCRIPTION
It was broken during https://github.com/aerospike/aerospike-prometheus-exporter/pull/104. Even the comment says it should be or.
Without this change, aerospike client tries to connect without TLS