### PR TITLE
Prevent exporter from detecting it is in Kubernetes

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -211,7 +211,7 @@ func (c *Config) FetchKubernetesInfo(md toml.MetaData) {
 	Cfg.Agent.IsKubernetes = false
 
 	if envKubeServiceHost != "" && len(strings.TrimSpace(envKubeServiceHost)) > 0 {
-		Cfg.Agent.IsKubernetes = true
+		Cfg.Agent.IsKubernetes = false
 		log.Info("Exporter is running in Kubernetes")
 
 		// get host-name


### PR DESCRIPTION
It prevents a breaking change where the operator reports the hostname as the service name instead of what we had before: the ip:port of Aerospike.